### PR TITLE
added new retry flag to space-cli apply command

### DIFF
--- a/space-cli/cmd/modules/deploy/deploy.go
+++ b/space-cli/cmd/modules/deploy/deploy.go
@@ -61,7 +61,7 @@ func deployService(dockerFilePath, serviceFilePath string) error {
 	}
 
 	// Time to apply the service file config
-	if err := operations.Apply(serviceFilePath, true, model.ApplyWithNoDelay); err != nil {
+	if err := operations.Apply(serviceFilePath, true, model.ApplyWithNoDelay, 1); err != nil {
 		return utils.LogError("Unable to apply service file config", err)
 	}
 

--- a/space-cli/cmd/modules/operations/commands.go
+++ b/space-cli/cmd/modules/operations/commands.go
@@ -180,11 +180,15 @@ func Commands() []*cobra.Command {
 			if err := viper.BindPFlag("file", cmd.Flags().Lookup("file")); err != nil {
 				_ = utils.LogError("Unable to bind the flag ('file')", err)
 			}
+			if err := viper.BindPFlag("retry", cmd.Flags().Lookup("retry")); err != nil {
+				_ = utils.LogError("Unable to bind the flag ('retry')", err)
+			}
 		},
 	}
 	apply.Flags().DurationP("delay", "", time.Duration(0), "Adds a delay between 2 subsequent request made by space cli to space cloud")
 	apply.Flags().BoolP("force", "", false, "Doesn't show warning prompts if some risky changes are made to the config")
 	apply.Flags().StringP("file", "f", "", "Path to the resource yaml file or directory")
+	apply.Flags().IntP("retry", "r", 1, "Number of retries in case of failure")
 	err = viper.BindEnv("file", "FILE")
 	if err != nil {
 		_ = utils.LogError("Unable to bind flag ('file') to environment variables", nil)
@@ -274,6 +278,7 @@ func actionDestroy(cmd *cobra.Command, args []string) error {
 func actionApply(cmd *cobra.Command, args []string) error {
 	delay := viper.GetDuration("delay")
 	isForce := viper.GetBool("force")
+	retry := viper.GetInt("retry")
 	var dirName string
 	file := viper.GetString("file")
 	if file == "" {
@@ -286,7 +291,7 @@ func actionApply(cmd *cobra.Command, args []string) error {
 	} else {
 		dirName = file
 	}
-	return Apply(dirName, isForce, delay)
+	return Apply(dirName, isForce, delay, retry)
 }
 
 func actionStart(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## What does this PR do?
This PR adds a new flag "retry" to space-cli apply command. It will retry a config in case of failure. The number of retries is provided as the argument.

## Link to related issue
This fixes #1505 

## Where should the reviewer start?
You can start reviewing from modules/operations/commands.go file inside space-cli directory.

## Recommendations for how to test this?
You need config files to test this. If you don't have config files then you can export by `space-cli get all` command. Make some errors inside the config files and then run the command `space-cli apply -f <location_of_files> --retry <no_of_retries>`. The CLI will try to apply the bad config file for the number of retries you mentioned.
